### PR TITLE
Add failing test to use npm scoped module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "@fraction/base16-css": "^1.0.1",
     "faucet": "0.0.1",
     "tape": "^4.4.0"
   },

--- a/test.js
+++ b/test.js
@@ -34,3 +34,8 @@ test('not uses main field in package.json', function(t) {
     , path.resolve(fixtures, 'not_use_main/index.css')
   )
 })
+
+test('not uses main field in package.json', function(t) {
+  t.plan(1)
+  t.ok(resolve.sync('@fraction/base16-css'))
+})


### PR DESCRIPTION
Currently throwing:

```
/home/christianbundy/src/style-resolve/node_modules/resolve/lib/sync.js:76
    throw err;
    ^

Error: Cannot find module '@fraction/base16-css' from '/home/christianbundy/src/style-resolve'
    at Function.module.exports [as sync] (/home/christianbundy/src/style-resolve/node_modules/resolve/lib/sync.js:74:15)
    at Function.resolveSync [as sync] (/home/christianbundy/src/style-resolve/index.js:22:19)
    at Test.<anonymous> (/home/christianbundy/src/style-resolve/test.js:40:16)
    at Test.bound [as _cb] (/home/christianbundy/src/style-resolve/node_modules/tape/lib/test.js:77:32)
    at Test.run (/home/christianbundy/src/style-resolve/node_modules/tape/lib/test.js:93:10)
    at Test.bound [as run] (/home/christianbundy/src/style-resolve/node_modules/tape/lib/test.js:77:32)
    at Immediate.next (/home/christianbundy/src/style-resolve/node_modules/tape/lib/results.js:81:19)
```

See: https://docs.npmjs.com/about-scopes